### PR TITLE
Backported to Java 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,8 +86,8 @@
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
           <configuration>
-            <source>1.7</source>
-            <target>1.7</target>
+            <source>1.6</source>
+            <target>1.6</target>
           </configuration>
         </plugin>
 

--- a/src/main/java/org/avaje/agentloader/AgentLoader.java
+++ b/src/main/java/org/avaje/agentloader/AgentLoader.java
@@ -168,9 +168,11 @@ public class AgentLoader {
         return new SolarisVirtualMachine(ATTACH_PROVIDER, pid);
       }
       
-    } catch (AttachNotSupportedException | IOException e) {
+    } catch (AttachNotSupportedException e) {
       throw new RuntimeException(e);
-      
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+
     } catch (UnsatisfiedLinkError e) {
       throw new IllegalStateException("Native library for Attach API not available in this JRE", e);
     }


### PR DESCRIPTION
This was necessary to ensure that I could run the tests for ebeanorm against Java 1.6.
