### PR TITLE
Fixed the path checker for inner jar which ends with '!/'

### DIFF
--- a/src/main/java/org/avaje/agentloader/AgentLoader.java
+++ b/src/main/java/org/avaje/agentloader/AgentLoader.java
@@ -141,9 +141,10 @@ public class AgentLoader {
     if (lastSlash < 0) {
       return false;
     }
-    String jarName = fullPath.substring(lastSlash + 1);
-    // Use startsWith so ignoring the version of the agent
-    return jarName.startsWith(partial);
+    /**
+     * Use 'contains' so ignoring the version of the agent and offset of inner jar
+     */
+    return fullPath.contains(partial);
   }
 
   private static final boolean isWindows() {


### PR DESCRIPTION
By using "contains", it work properly for inner JAR which ends with "!/".

For example, the previous method will return FALSE if the full path is "file:/mnt/data/workspace/uoa.projects/ram/war/target/ram-war-2.1.1-SNAPSHOT.war!/lib/avaje-ebeanorm-agent-4.5.3.jar!/" .

