### PR TITLE
ignore jdk.attach.allowAttachSelf and use external-attach for JDK > 8

### DIFF
--- a/src/main/java/org/avaje/agentloader/AgentLoader.java
+++ b/src/main/java/org/avaje/agentloader/AgentLoader.java
@@ -44,10 +44,6 @@ public class AgentLoader {
       log.trace("using direct-attach for java {} < 9", version);
       return true;
 
-    } else if (Boolean.getBoolean(JDK_ALLOW_SELF_ATTACH)) {
-      log.trace("using direct-attach, because {} is set", JDK_ALLOW_SELF_ATTACH);
-      return true;
-
     } else {
       log.trace("using external-attach for java {}", version);
       return false;


### PR DESCRIPTION
Looks like direct-attach use some JDK 8 specific features. Better ignore `jdk.attach.allowAttachSelf` and do external-attach for JDK > 8.
Anyway, proposed changes helped to fix https://github.com/ArtsiomCh/CMake/issues/7 :
```
java.lang.RuntimeException: java.lang.IllegalStateException: Native library for Attach API not available in this JRE (probably no JDK on classpath)
    at org.avaje.agentloader.AgentLoader.loadAgent(AgentLoader.java:92)
...
```
PS Didn't dive deep into the direct-attach code, it's possible a better solution exists.